### PR TITLE
Adds Video Training Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ have more control. You can see a list of all available fiddles
 metal-component.
 * [Build Tools](docs/build-tools.md) - Covers the build tools created to be used
 in Metal.js projects, like gulp-metal.
+* [Metal.js Core Video Training Links](video-training.md)

--- a/video-training.md
+++ b/video-training.md
@@ -1,0 +1,8 @@
+# Metal.js Video Training
+
+* [Day 1 - Part 1](https://www.youtube.com/watch?v=Et5XZLKbivg)
+* [Day 1 - Part 2](https://www.youtube.com/watch?v=Ud025UrB-VA)
+* [Day 2 - Part 1](https://www.youtube.com/watch?v=g2UtOuNfZ6k)
+* [Day 2 - Part 2](https://www.youtube.com/watch?v=w0cKgGuVNcE)
+* [Day 3](https://www.youtube.com/watch?v=-moIRPzyNwo&feature=youtu.be)
+* [Day 4](https://www.youtube.com/watch?v=sbqRzbxyydU)


### PR DESCRIPTION
Hey, guys. Due to a Hackaday in Recife office, that will happen soon, and a request from @pragmaticivan. I added the links of the Metal.JS Core Training.

I don't remember which topics were covered in each day, I have to watch them again, that's why I haven't written down descriptions. 